### PR TITLE
Update `upload-artifact` and `download-artifact` versions.

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: pdm-project/setup-pdm@v3
         name: Setup PDM
         with:
@@ -20,7 +20,7 @@ jobs:
           pdm install
           pdm build
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist
@@ -34,7 +34,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheels
           path: dist


### PR DESCRIPTION
Hello @songololo

Just some updates. [Version 3 of `{up,down}load-artifact` is deprecated, and will break soon](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#artifacts-v3-brownouts). I also updated checkout since I was there.

[Enabling dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) might be of use to you.
